### PR TITLE
Ajout tooltip sur collapser sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,3 +61,13 @@ if communes:
 # affichage logos partenaires
 st.sidebar.image("assets/images/logo_opt.png", width=250)
 st.sidebar.image("assets/images/logo_unc.jpg", width=250)
+
+# Ajout du style et du script pour le tooltip
+st.markdown("""
+<style>
+    [data-testid="stBaseButton-headerNoPadding"]:hover::after {
+        content: "Ouvrir / Fermer";
+        color: white;
+    }
+</style>
+""", unsafe_allow_html=True)


### PR DESCRIPTION
# 🔨 Fix
- #44 

# 📷 Demo
[Capture vidéo du 2024-10-15 14-25-21.webm](https://github.com/user-attachments/assets/c0641376-a676-48fd-b833-582a5fba773d)


Je n'ai pas pu faire en sorte de changer le texte du tooltip en fonction du status de la barre puisque je n'ai pas trouver comment le connaitre comme indiqué dans ce [poste](https://discuss.streamlit.io/t/how-to-check-the-sidebar-state/42609).