### PR TITLE
Ajout graphique historique des temps d'attente pour une agence donnée…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ cd temps-attente-streamlit
 # Builder l'image  
 docker build -t hellooptnc .
 
-# Créer un fichier .env avec la clé API
-OPTNC_WAITINGTIME_APIKEY=[clé API]
+# Créer un fichier .env avec les clés API
+OPTNC_WAITINGTIME_APIKEY=[clé API APIGEE]
+OPTNC_WAITINGTIME_APIKEY_RAPIDAPI=[clé API Rapidapi]
 
 # Démarrer l'application via Docker  
 docker run -p 80:8501 --env-file .env hellooptnc
@@ -73,9 +74,9 @@ Pour accéder à l'application, aller sur : http://localhost
 xdg-open http://localhost
 ```
 
-👀 **Vérifier** que la page web affiche bien "Hello OPT-NC" 
+👀 **Vérifier** que la page web s'affiche 
 
-![image](https://github.com/user-attachments/assets/4a727dd3-908c-4dd5-8468-170284f2e3fa)
+![image](https://github.com/user-attachments/assets/c89221c0-4c13-4d10-8ec7-09fd1b77811f)
 
 
 

--- a/app.py
+++ b/app.py
@@ -83,8 +83,8 @@ if communes:
         # Récupérer l'historique de la journée actuelle
         df = fetch_agence_historique(id_agence,debut,fin)
         if not df.empty:          
-            #afficher le graphique
-            st.line_chart(df.set_index("Time"))
+            #afficher l'histogramme
+            st.bar_chart(df.set_index("Time"))
         else:
             st.write("Aucune donnée disponible pour l'historique de l'agence sélectionnée.")
         

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from streamlit_autorefresh import st_autorefresh
-from utils import INTERVALLE_AUTOREFRESH, get_current_time, check_valid_hours, gauge, fetch_communes, fetch_agences, fetch_agence_by_id
+from utils import INTERVALLE_AUTOREFRESH, get_current_time, check_valid_hours, gauge, fetch_communes, fetch_agences, fetch_agence_by_id,fetch_agence_historique
+from datetime import timedelta
 
 
 st.set_page_config(page_title='Temps d\'attente en agence OPT-NC', layout = 'wide', page_icon = 'assets/images/favicon.jpg', initial_sidebar_state = 'auto')
@@ -72,6 +73,20 @@ if communes:
             """, 
             unsafe_allow_html=True
         )
+
+        #récuper l'id de l'agence
+        id_agence=st.query_params["idAgence"]
+        # Début de la journée à 7h45 avec décalage de -11 heures (fuseau UTC)
+        debut = (get_current_time().replace(hour=7, minute=45, second=0, microsecond=0) - timedelta(hours=11)).strftime("%Y-%m-%dT%H:%M:%S")
+        #heure de fin = heure actuelle moins un décalage de 11 heures
+        fin = (get_current_time() - timedelta(hours=11)).strftime("%Y-%m-%dT%H:%M:%S")
+        # Récupérer l'historique de la journée actuelle
+        df = fetch_agence_historique(id_agence,debut,fin)
+        if not df.empty:          
+            #afficher le graphique
+            st.line_chart(df.set_index("Time"))
+        else:
+            st.write("Aucune donnée disponible pour l'historique de l'agence sélectionnée.")
         
 # affichage logos partenaires
 st.sidebar.image("assets/images/logo_opt.png", width=250)

--- a/utils.py
+++ b/utils.py
@@ -5,9 +5,11 @@ from dotenv import load_dotenv
 import pytz
 import plotly.graph_objects as go
 import requests
+import pandas as pd
 
 INTERVALLE_AUTOREFRESH = 3 * 60 # 3 minutes
 API_TEMPS_ATTENTE_BASE_URL = "https://api.opt.nc/temps-attente-agences/"
+API_TEMPS_ATTENTE_BASE_URL_RAPIDAPI = "https://temps-attente-en-agence.p.rapidapi.com/"
 
 # Obtenir la datetime dans le fuseau horaire de NC
 def get_current_time():
@@ -33,6 +35,10 @@ def load_apikey():
     # Charger le fichier .env
     load_dotenv()
     return os.getenv("OPTNC_WAITINGTIME_APIKEY")
+
+def load_apikey_rapidapi():
+    load_dotenv()
+    return os.getenv("OPTNC_WAITINGTIME_APIKEY_RAPIDAPI")
 
 def gauge(temps_attente):
     plage_temps = [5, 10, 15]
@@ -63,6 +69,11 @@ APIKEY = load_apikey()
 headers = {
     "x-apikey": APIKEY,
     "Content-Type": "application/json"
+}
+APIKEY_RAPIDAPI = load_apikey_rapidapi()
+headers_rapidapi = {
+    "x-rapidapi-host":"temps-attente-en-agence.p.rapidapi.com",
+    "x-rapidapi-key": APIKEY_RAPIDAPI
 }
 
 # pas de ttl puisqu'on ne l'appel qu'une seule fois
@@ -106,3 +117,29 @@ def fetch_agence_by_id(id_agence):
     else:
         st.error(f"Erreur lors de la récupération de l'agence {id_agence} : {response.status_code}")
         return []
+
+@st.cache_data(ttl=INTERVALLE_AUTOREFRESH, show_spinner=False)
+def fetch_agence_historique(id_agence,debut,fin):
+    params = {
+        "debut": debut,
+        "fin": fin
+    }
+    response = requests.get(API_TEMPS_ATTENTE_BASE_URL_RAPIDAPI + f"agences/{id_agence}/historique", headers=headers_rapidapi, params=params)
+    if response.status_code == 200:
+        historique = response.json()
+        # Récupération des timestamps et des temps d'attente max en minutes
+        times = [entry['timestamp'] for entry in historique]
+        waiting_times = [entry['realMaxWaitingTimeMs'] / 60000 for entry in historique]  # Convertir en minutes
+        # Convertir les timestamps en objets datetime
+        times = pd.to_datetime(times)
+        # Ajouter un décalage de +11 heures pour correspondre à UTC+11
+        times = times + pd.Timedelta(hours=11)
+        # Créer un DataFrame avec les données
+        df = pd.DataFrame({
+            "Time": times,
+            "Waiting Time (minutes)": waiting_times
+        })
+        return df
+    else:
+        st.error(f"Erreur lors de la récupération de l'historique pour l'agence {id_agence} : {response.status_code}")
+        return [], []

--- a/utils.py
+++ b/utils.py
@@ -131,7 +131,7 @@ def fetch_agence_historique(id_agence,debut,fin):
         times = [entry['timestamp'] for entry in historique]
         waiting_times = [entry['realMaxWaitingTimeMs'] / 60000 for entry in historique]  # Convertir en minutes
         # Convertir les timestamps en objets datetime
-        times = pd.to_datetime(times)
+        times = pd.to_datetime(times, format="%Y-%m-%dT%H:%M:%S.%f", errors='coerce')
         # Ajouter un décalage de +11 heures pour correspondre à UTC+11
         times = times + pd.Timedelta(hours=11)
         # Créer un DataFrame avec les données


### PR DESCRIPTION
fixes
- #38
-Ajout du graphique de l'historique avec [Rapidapi](https://rapidapi.com/opt-nc-opt-nc-default/api/temps-attente-en-agence/playground/apiendpoint_a4657945-b05c-43b8-9e90-0df6ae36b139)
-Modification Readme : ajouter une nouvelle clé API [Rapidapi](https://rapidapi.com/opt-nc-opt-nc-default/api/temps-attente-en-agence/playground/apiendpoint_a4657945-b05c-43b8-9e90-0df6ae36b139) dans le fichier.env
![image](https://github.com/user-attachments/assets/92b17fa7-1485-43de-a8aa-08b693961a72)

